### PR TITLE
add grails serverURL to gsp

### DIFF
--- a/grails-app/views/showRestApi/index.gsp
+++ b/grails-app/views/showRestApi/index.gsp
@@ -21,7 +21,7 @@
     var baseUrl = '';
     $(function () {
       window.swaggerUi = new SwaggerUi({
-        url: "http://localhost:8080/nerdbase/api-docs",
+        url: "${grailsApplication.config.grails.serverURL}/api-docs",
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
         onComplete: function (swaggerApi, swaggerUi) {


### PR DESCRIPTION
Simple change makes it load your api docs by default using grails.serverURL
