### PR TITLE
Updated BuildConfig to promote compatibility.

### DIFF
--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -15,7 +15,8 @@ class Swagger4jaxrsGrailsPlugin {
     def license = "APACHE"
     def organization = [ name: "nerdErg Pty. Ltd.", url: "http://www.nerderg.com/" ]
     def developers = [
-        [ name: "Angel Ruiz", email: "aruizca@gmail.com" ]
+        [ name: "Angel Ruiz", email: "aruizca@gmail.com" ],
+        [ name: "Aaron Brown", email: "brown.aaron.lloyd@gmail.com"],
     ]
     def issueManagement = [ system: "GitHub", url: "https://github.com/nerdErg/swagger4jaxrs/issues" ]
     def scm = [ url: "https://github.com/nerdErg/swagger4jaxrs" ]

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,18 +17,26 @@ grails.project.dependency.resolution = {
         compile 'com.fasterxml.jackson.core:jackson-core:2.1.0'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.1.0'
 
-        test 'org.spockframework:spock-grails-support:0.7-groovy-2.0'
+        if (owner.grailsVersion ==~ /2\.2\..*/) {
+            test('org.spockframework:spock-grails-support:0.7-groovy-2.0') {
+                export = false
+            }
+        }
     }
 
     plugins {
-        compile ':jaxrs:0.8'
+        runtime(':jaxrs:0.8') {
+            export = false
+        }
 
         build ':release:2.2.1', ':rest-client-builder:1.0.3', {
             export = false
         }
 
         test(':spock:0.7') {
-            exclude "spock-grails-support"
+            if (owner.grailsVersion ==~ /2\.2\..*/) {
+                exclude "spock-grails-support"
+            }
             export = false
         }
     }


### PR DESCRIPTION
Since I develop in 2.1.1 for now, I've modified the BuildConfig so that
it does a few nifty things:
1. It sets up spock correctly based on Grails version, at least for 2.0/2.1 and 2.2 .
2. I've disabled the export of the dependency on spock resources, as that was causing major problems and should not be included in applications anyway; that is only for the plugin and should remain only in the plugin.
3. I've disabled the export of jaxrs. While I understand that may make it convenient, I feel that it is more appropriate to allow the application to specify what version of JaxRS is it is using. Since I am running 2.1.1, JaxRS 0.9 is my compatible version. Otherwise, I would have to specifically export jaxrs from this plugin's transitive dependencies, just to include my version; this is not good plugin practice.
