### PR TITLE
Bean to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,33 @@ compile ":swagger4jaxrs:0.1"
 ```
 
 ## Configuration
-Next we need to configure Swagger in our host application. To do that, we have to add and customize the following Spring Bean declaration within your **resources.groovy** file located at **grails-app/conf/spring/resources.groovy**:
+
+The following configuration is the minimum the plugin requires, which can be placed in the ```grails-app/conf/Config.groovy``` file:
 
 ```groovy
-    import com.wordnik.swagger.jaxrs.config.BeanConfig
-    beans = {
+grails.serverUrl = "http://localhost:8080/ExampleApp"
 
-        swaggerConfig(BeanConfig) {
-            resourcePackage = "<package with your resources>"
-            version = "<your REST API version>"
-            basePath = "${grailsApplication.config.grails.serverURL}/api"
-            title = "<your App Name>"
-            description = "<your description here>"
-            contact = "<your email>"
-            license = "<your license>"
-            licenseUrl = "<your license link>"
-            scan = true
-        }
-    }
+'swagger4jaxrs' {
+    resourcePackage = "<package with your resources>"
+}
+```
+
+And this is the fully enumerated setup:
+
+```groovy
+grails.serverUrl = "http://localhost:8080/ExampleApp"
+
+'swagger4jaxrs' {
+    resourcePackage = "<package with your resources>"
+
+    version = "<your REST API version>" // Default "1".
+    title = "<your desired title>" // Default: App Name.
+    description = "<your description here>"
+    contact = "<your email>"
+    license = "<your license>"
+    licenseUrl = "<your license link>"
+    scan = true
+}
 ```
 
 If you are updating from a previous version of swagger4jaxrs and want to use the above method to configure your app you will need to remove the bean declaration from applicationContext.xml that you had previously added. You will also have to define the grails.serverURL in your config.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ compile ":swagger4jaxrs:0.1"
 The following configuration is the minimum the plugin requires, which can be placed in the ```grails-app/conf/Config.groovy``` file:
 
 ```groovy
-grails.serverUrl = "http://localhost:8080/ExampleApp"
-
 'swagger4jaxrs' {
     resourcePackage = "<package with your resources>"
 }
@@ -29,8 +27,6 @@ grails.serverUrl = "http://localhost:8080/ExampleApp"
 And this is the fully enumerated setup:
 
 ```groovy
-grails.serverUrl = "http://localhost:8080/ExampleApp"
-
 'swagger4jaxrs' {
     resourcePackage = "<package with your resources>"
 
@@ -43,9 +39,6 @@ grails.serverUrl = "http://localhost:8080/ExampleApp"
     scan = true
 }
 ```
-
-If you are updating from a previous version of swagger4jaxrs and want to use the above method to configure your app you will need to remove the bean declaration from applicationContext.xml that you had previously added. You will also have to define the grails.serverURL in your config.
-
 
 Make sure you have added the Swagger annotations in your JAX-RS "resources" with the required meta information to generate a comprehensive documentarion for you REST API. Next there is a good [example](https://github.com/wordnik/swagger-core/tree/master/samples "Swager implementation samples") to show you how:
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
 @Path("/api/user")
-@Api(value="/user", description = "Operations about user")
-@Produces(["application/json"])
+@Api(value="/api/user", description = "Operations about user")
+@Produces({"application/json"})
 public class UserResource {
 	static UserData userData = new UserData();
 

--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -38,26 +38,40 @@ class Swagger4jaxrsGrailsPlugin {
 
         ConfigObject local = application.config.'swagger4jaxrs'
 
-        if (local == null || local.isEmpty()) {
-            throw new IllegalStateException("The swagger4jaxrs config is missing.")
-        }
+        validateLocalConfig(local)
 
         swaggerConfig(BeanConfig) { bean ->
             bean.autowire = true
             resourcePackage = local.resourcePackage
-            version = local.version
+            version = local.version ?: "1"
             basePath = "${application.config.grails.serverURL}/api"
-            title = local.title
-            description = local.description
-            contact = local.contact
-            license = local.license
-            licenseUrl = local.licenseUrl
+            title = local.title ?: grails.util.Metadata.current.'app.name'
+            description = local.description ?: ""
+            contact = local.contact ?: ""
+            license = local.license ?: ""
+            licenseUrl = local.licenseUrl ?: ""
             scan = local.scan ?: true
         }
     }
 
     def onConfigChange = { event ->
         mergeConfig(application)
+
+        ConfigObject local = application.config.'swagger4jaxrs'
+
+        validateLocalConfig(local)
+
+        event.ctx.getBean('swaggerConfig').with {
+            resourcePackage = local.resourcePackage
+            version = local.version ?: "1"
+            basePath = "${application.config.grails.serverURL}/api"
+            title = local.title ?: grails.util.Metadata.current.'app.name'
+            description = local.description ?: ""
+            contact = local.contact ?: ""
+            license = local.license ?: ""
+            licenseUrl = local.licenseUrl ?: ""
+            scan = local.scan ?: true
+        }
     }
 
     /**
@@ -73,5 +87,15 @@ class Swagger4jaxrsGrailsPlugin {
         config.putAll(secondaryConfig.org.grails.jaxrs.merge(currentConfig))
 
         app.config.org.grails.jaxrs = config
+    }
+
+    private void validateLocalConfig(ConfigObject local) {
+        if (local.isEmpty()) {
+            throw new IllegalStateException("The swagger4jaxrs config is missing.")
+        }
+
+        if (local.resourcePackage.isEmpty()) {
+            throw new IllegalStateException("The swagger4jaxrs config requires a resourcePackage path.")
+        }
     }
 }

--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -44,7 +44,7 @@ class Swagger4jaxrsGrailsPlugin {
             bean.autowire = true
             resourcePackage = local.resourcePackage
             version = local.version ?: "1"
-            basePath = "${application.config.grails.serverURL}/api"
+            basePath = "${application.config.grails.serverURL}"
             title = local.title ?: grails.util.Metadata.current.'app.name'
             description = local.description ?: ""
             contact = local.contact ?: ""
@@ -64,7 +64,7 @@ class Swagger4jaxrsGrailsPlugin {
         event.ctx.getBean('swaggerConfig').with {
             resourcePackage = local.resourcePackage
             version = local.version ?: "1"
-            basePath = "${application.config.grails.serverURL}/api"
+            basePath = "${application.config.grails.serverURL}"
             title = local.title ?: grails.util.Metadata.current.'app.name'
             description = local.description ?: ""
             contact = local.contact ?: ""

--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -2,8 +2,6 @@ import grails.util.Environment
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 
-import org.codehaus.groovy.grails.web.mapping.LinkGenerator
-
 import com.wordnik.swagger.jaxrs.config.BeanConfig
 
 class Swagger4jaxrsGrailsPlugin {
@@ -44,7 +42,6 @@ class Swagger4jaxrsGrailsPlugin {
             bean.autowire = true
             resourcePackage = local.resourcePackage
             version = local.version ?: "1"
-            basePath = "${application.config.grails.serverURL}"
             title = local.title ?: grails.util.Metadata.current.'app.name'
             description = local.description ?: ""
             contact = local.contact ?: ""
@@ -64,7 +61,6 @@ class Swagger4jaxrsGrailsPlugin {
         event.ctx.getBean('swaggerConfig').with {
             resourcePackage = local.resourcePackage
             version = local.version ?: "1"
-            basePath = "${application.config.grails.serverURL}"
             title = local.title ?: grails.util.Metadata.current.'app.name'
             description = local.description ?: ""
             contact = local.contact ?: ""

--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -25,16 +25,15 @@ class Swagger4jaxrsGrailsPlugin {
     def issueManagement = [ system: "GitHub", url: "https://github.com/nerdErg/swagger4jaxrs/issues" ]
     def scm = [ url: "https://github.com/nerdErg/swagger4jaxrs" ]
 
+    def dependsOn = [
+        jaxrs: "0.8 > *"
+    ]
+
     def loadAfter = [
         "jaxrs"
     ]
 
     def doWithSpring = {
-        /*
-        if (! manager?.hasGrailsPlugin("jaxrs") {
-            throw new IllegalStateException("JaxRS is required for swagger4jaxrs.")
-        }
-        */
         mergeConfig(application)
 
         ConfigObject local = application.config.'swagger4jaxrs'

--- a/Swagger4jaxrsGrailsPlugin.groovy
+++ b/Swagger4jaxrsGrailsPlugin.groovy
@@ -2,6 +2,10 @@ import grails.util.Environment
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 
+import org.codehaus.groovy.grails.web.mapping.LinkGenerator
+
+import com.wordnik.swagger.jaxrs.config.BeanConfig
+
 class Swagger4jaxrsGrailsPlugin {
     def version = "0.2-SNAPSHOT"
     def grailsVersion = "2.0 > *"
@@ -21,8 +25,36 @@ class Swagger4jaxrsGrailsPlugin {
     def issueManagement = [ system: "GitHub", url: "https://github.com/nerdErg/swagger4jaxrs/issues" ]
     def scm = [ url: "https://github.com/nerdErg/swagger4jaxrs" ]
 
+    def loadAfter = [
+        "jaxrs"
+    ]
+
     def doWithSpring = {
+        /*
+        if (! manager?.hasGrailsPlugin("jaxrs") {
+            throw new IllegalStateException("JaxRS is required for swagger4jaxrs.")
+        }
+        */
         mergeConfig(application)
+
+        ConfigObject local = application.config.'swagger4jaxrs'
+
+        if (local == null || local.isEmpty()) {
+            throw new IllegalStateException("The swagger4jaxrs config is missing.")
+        }
+
+        swaggerConfig(BeanConfig) { bean ->
+            bean.autowire = true
+            resourcePackage = local.resourcePackage
+            version = local.version
+            basePath = "${application.config.grails.serverURL}/api"
+            title = local.title
+            description = local.description
+            contact = local.contact
+            license = local.license
+            licenseUrl = local.licenseUrl
+            scan = local.scan ?: true
+        }
     }
 
     def onConfigChange = { event ->

--- a/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
+++ b/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
@@ -1,6 +1,19 @@
 package com.nerderg.grails.plugins.swagger4jaxrs
 
+import com.wordnik.swagger.jaxrs.config.BeanConfig
+
+import org.codehaus.groovy.grails.web.mapping.LinkGenerator
+
 class ShowRestApiController {
 
-    def index() { }
+    BeanConfig swaggerConfig
+    LinkGenerator grailsLinkGenerator
+
+    def index() {
+        String basePath = grailsLinkGenerator.serverBaseURL
+
+        swaggerConfig.basePath = basePath
+
+        render(view: 'index', model: [apiDocsPath: "${basePath}/api-docs"])
+    }
 }

--- a/grails-app/views/showRestApi/index.gsp
+++ b/grails-app/views/showRestApi/index.gsp
@@ -21,7 +21,7 @@
     var baseUrl = '';
     $(function () {
       window.swaggerUi = new SwaggerUi({
-        url: "${grailsApplication.config.grails.serverURL}/api-docs",
+        url: "${apiDocsPath}",
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
         onComplete: function (swaggerApi, swaggerUi) {


### PR DESCRIPTION
This makes it so you don't have to use the bean as the directions state in the README. The bean is managed by the plugin itself. All that is needed is to setup the appropriate config.

It also sets a dependency to the JaxRS Plugin, to ensure that at least 0.8 is installed.

I recommend merging #13 first.
