### PR TITLE
Used context path over GrailsLinkGenerator.

### DIFF
--- a/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
+++ b/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
@@ -2,18 +2,13 @@ package com.nerderg.grails.plugins.swagger4jaxrs
 
 import com.wordnik.swagger.jaxrs.config.BeanConfig
 
-import org.codehaus.groovy.grails.web.mapping.LinkGenerator
-
 class ShowRestApiController {
 
     BeanConfig swaggerConfig
-    LinkGenerator grailsLinkGenerator
 
     def index() {
-        String basePath = grailsLinkGenerator.serverBaseURL
+        swaggerConfig.basePath = request.contextPath
 
-        swaggerConfig.basePath = basePath
-
-        render(view: 'index', model: [apiDocsPath: "${basePath}/api-docs"])
+        render(view: 'index', model: [apiDocsPath: "${request.contextPath}/api-docs"])
     }
 }


### PR DESCRIPTION
The GrailsLinkGenerator actually uses the hostname, which looks a bit
weird when deployed to a server on a WAR.

I've changed it to use the contextPath of the request.
