### PR TITLE
Using Context Path.

### DIFF
--- a/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
+++ b/grails-app/controllers/com/nerderg/grails/plugins/swagger4jaxrs/ShowRestApiController.groovy
@@ -2,18 +2,12 @@ package com.nerderg.grails.plugins.swagger4jaxrs
 
 import com.wordnik.swagger.jaxrs.config.BeanConfig
 
-import org.codehaus.groovy.grails.web.mapping.LinkGenerator
-
 class ShowRestApiController {
-
     BeanConfig swaggerConfig
-    LinkGenerator grailsLinkGenerator
 
     def index() {
-        String basePath = grailsLinkGenerator.serverBaseURL
+        swaggerConfig.basePath = request.contextPath
 
-        swaggerConfig.basePath = basePath
-
-        render(view: 'index', model: [apiDocsPath: "${basePath}/api-docs"])
+        render(view: 'index', model: [apiDocsPath: "${request.contextPath}/api-docs"])
     }
 }


### PR DESCRIPTION
This is more appropriate for what needs to be done. The
GrailsLinkGenerator created URLs based on hostname of server
(obviously), but this means that the Try-It-Out function had odd
behavior and did not use the DNS name.

The Context Path solves that issue.
